### PR TITLE
Remove Yeti2024 log now that it is Rejected

### DIFF
--- a/log_list.md
+++ b/log_list.md
@@ -15,7 +15,6 @@ certificates or inspecting the certificates that have been logged.
 |Google 'Xenon2024' log         | https://ct.googleapis.com/logs/eu1/xenon2024/| Usable   | 86400 |  2024-01-01T00:00:00Z |  2025-01-01T00:00:00Z |  Google        |  google-ct-logs@googlegroups.com  |
 |Cloudflare 'Nimbus2023' Log    | https://ct.cloudflare.com/logs/nimbus2023/   | Usable   | 86400 |  2023-01-01T00:00:00Z |  2024-01-01T00:00:00Z |  Cloudflare    |  ct-logs@cloudflare.com           |
 |Cloudflare 'Nimbus2024' Log    | https://ct.cloudflare.com/logs/nimbus2024/   | Usable   | 86400 |  2024-01-01T00:00:00Z |  2025-01-01T00:00:00Z |  Cloudflare    |  ct-logs@cloudflare.com           |
-|DigiCert Yeti2023 Log          | https://yeti2023.ct.digicert.com/log/        | Retired  | 86400 |  2023-01-01T00:00:00Z |  2024-01-01T00:00:00Z |  DigiCert      |  ctops@digicert.com               |
 |DigiCert Yeti2024 Log          | https://yeti2024.ct.digicert.com/log/        | Usable   | 86400 |  2024-01-01T00:00:00Z |  2025-01-01T00:00:00Z |  DigiCert      |  ctops@digicert.com               |
 |DigiCert Yeti2025 Log          | https://yeti2025.ct.digicert.com/log/        | Usable   | 86400 |  2025-01-01T00:00:00Z |  2026-01-01T00:00:00Z |  DigiCert      |  ctops@digicert.com               |
 |DigiCert Nessie2023 Log        | https://nessie2023.ct.digicert.com/log/      | Usable   | 86400 |  2023-01-01T00:00:00Z |  2024-01-01T00:00:00Z |  DigiCert      |  ctops@digicert.com               |


### PR DESCRIPTION
The DigiCert Yeti2024 log was transitioned from Retired to Rejected (see the announcement to ct-policy@ [1]), so removing it from the informational log list here.

[1]: https://groups.google.com/a/chromium.org/g/ct-policy/c/6mvSoETm9Qk/m/yLapkocjAgAJ