### PR TITLE
Offer more clarity on incident response (and some minor wordsmithing)

### DIFF
--- a/ct_policy.md
+++ b/ct_policy.md
@@ -9,11 +9,11 @@ circumstances where
 [enterprise](https://cloud.google.com/docs/chrome-enterprise/policies/?policy=CertificateTransparencyEnforcementDisabledForLegacyCas)
 [policies](https://cloud.google.com/docs/chrome-enterprise/policies/?policy=CertificateTransparencyEnforcementDisabledForUrls)
 are set by an administrator. Certificates that are accompanied by SCTs that
-satisfy this Policy are said to be *CT Compliant*.
+satisfy this policy are said to be *CT Compliant*.
 
 CT Compliance is achieved by a certificate and set of accompanying SCTs by
 meeting a set of technical requirements enforced by the Chrome browser during
-certificate validation, which are defined in this Policy. The issuance of
+certificate validation, which are defined in this policy. The issuance of
 certificates that are not CT compliant is **not** considered mis-issuance or a
 violation of Chrome’s root program; such certificates will simply fail to
 validate in CT-enforcing versions of Chrome.

--- a/ct_policy.md
+++ b/ct_policy.md
@@ -21,20 +21,20 @@ validate in CT-enforcing versions of Chrome.
 ---
 
 ## CT Log States
-CT Compliance in Chrome is determined by evaluating SCTs from CT Logs and
-ensuring that these Logs are in the correct state(s) at time of check. The set
-of possible states a CT Log can be in is: 
+CT Compliance in Chrome is determined by evaluating SCTs from CT logs and
+ensuring that these logs are in the correct state(s) at time of check. The set
+of possible states a CT log can be in is:
 * `Pending`,
 * `Qualified`,
 * `Usable`,
-* `ReadOnly`, 
+* `ReadOnly`,
 * `Retired`, and
-* `Rejected` 
+* `Rejected`
 
 In order to assist with understanding the requirements for CT compliance in
-Chrome, the definition of these states, the requirements of Logs in each state,
+Chrome, the definition of these states, the requirements of logs in each state,
 as well as how these states impact Chrome behavior are described in detail in
-the [CT Log Lifecycle Explainer](log_states.md). 
+the [CT Log Lifecycle Explainer](log_states.md).
 
 ---
 
@@ -45,41 +45,41 @@ of Chrome, all publicly-trusted TLS certificates are required to be CT Compliant
 to successfully validate.
 
 When evaluating a certificate for CT Compliance, Chrome considers several
-factors including how many SCTs are present, who operates the CT Log that issued
-the SCT, and what state the CT Log that issued the SCT was in, both at the time
+factors including how many SCTs are present, who operates the CT log that issued
+the SCT, and what state the CT log that issued the SCT was in, both at the time
 the certificate is being validated, and at the time the SCT was created by the
-CT Log.
+CT log.
 
 Depending on how the SCTs are presented to Chrome, CT compliance can be achieved
 by meeting one of the following criteria:
 
 **Embedded SCTs:**
-1. At least one Embedded SCT from a CT Log that was `Qualified,` `Usable,` or
+1. At least one Embedded SCT from a CT log that was `Qualified,` `Usable,` or
    `ReadOnly` at the time of check; and
-2. There are Embedded SCTs from at least N distinct CT Logs that were
+2. There are Embedded SCTs from at least N distinct CT logs that were
    `Qualified`, `Usable`, `ReadOnly`, or `Retired` at the time of check, where N
    is defined in the following table; and
 3. Among the SCTs satisfying requirement 2, at least two SCTs must be issued
-   from distinct CT Log Operators as recognized by Chrome; and
+   from distinct CT log operators as recognized by Chrome; and
 4. Among the SCTs satisfying requirement 2, at least one SCT must be issued from
    a log recognized by Chrome as being RFC6962-compliant.
 
-| Certificate Lifetime | Number of SCTs from distinct CT Logs |
+| Certificate Lifetime | Number of SCTs from distinct CT logs |
 |:---:|:---:|
 | <= 180 days | 2 |
 | > 180 days | 3 |
 
 **SCTs delivered via OCSP or TLS:**
-1. At least two SCTs from a CT Log that was `Qualified`, `Usable`, or `ReadOnly`
+1. At least two SCTs from a CT log that was `Qualified`, `Usable`, or `ReadOnly`
    at the time of check; and
 2. Among the SCTs satisfying requirement 1, at least two SCTs must be issued
-   from distinct CT Log Operators as recognized by Chrome; and
+   from distinct CT log operators as recognized by Chrome; and
 3. Among the SCTs satisfying requirement 1, at least one SCT must be issued from
    a CT log recognized by Chrome as being RFC6962-compliant.
 
-For both embedded SCTs and those delivered via OCSP or TLS, Log Operator
+For both embedded SCTs and those delivered via OCSP or TLS, log operator
 uniqueness is defined as having separate entries within the `operators` section
-of [log_list.json](log_lists.md). In the rare situation that a CT Log changes
+of [log_list.json](log_lists.md). In the rare situation that a CT log changes
 operators during its lifetime, CT logs in the [v3 log list
 schema](https://www.gstatic.com/ct/log_list/v3/log_list_schema.json) optionally
 contain an list of `previous_operators`, accompanied by the final timestamp that
@@ -95,9 +95,9 @@ the SCT, will not affect a certificate’s CT Compliance status positively or
 negatively.
 
 In order to contribute to a certificate’s CT Compliance, an SCT must have been
-issued before the Log’s `Retired` timestamp, if one exists. Chrome uses the
-earliest SCT among all SCTs presented to evaluate CT compliance against CT Log
-`Retired` timestamps. This accounts for edge cases in which a CT Log becomes
+issued before the log’s `Retired` timestamp, if one exists. Chrome uses the
+earliest SCT among all SCTs presented to evaluate CT compliance against CT log
+`Retired` timestamps. This accounts for edge cases in which a CT log becomes
 `Retired` during the process of submitting certificate logging requests.
 
 "Embedded SCT" means an SCT delivered via the SignedCertificateTimestampList
@@ -109,7 +109,7 @@ Chrome.
 ---
 
 ## How CT Logs are added to Chrome
-The criteria for how CT Logs can become `Qualified`, as well as what
+The criteria for how CT logs can become `Qualified`, as well as what
 circumstances can cause them to become `Retired`, can be found in the [Chrome CT
 Log Policy](log_policy.md).
 
@@ -126,7 +126,7 @@ weeks), and uses a log list format that Chrome understands.
 If the installed version of Chrome has not applied security updates and has been
 unable to obtain an updated CT log list from the Component Updater for 70 days
 or more, then CT enforcement will be disabled. This timeout provides a critical
-assurance to the CT ecosystem that new CT Logs are able to safely transition to
+assurance to the CT ecosystem that new CT logs are able to safely transition to
 `Usable` within a fixed amount of time after becoming `Qualified`. All
 CT-enforcing user agents are strongly encouraged to implement a similar
 enforcement timeout to maximize compatibility with the existing ecosystem.

--- a/log_lists.md
+++ b/log_lists.md
@@ -1,15 +1,17 @@
 # Chrome's CT Log Lists
 
-Google publishes what CT logs are known and trusted by the Chrome browser
-(collectively the "CT Log Lists"), predominately in JSON format. There are two
-varieties of these lists published:
+The Chrome team publishes known CT logs (collectively the "CT Log
+Lists"), predominately in JSON format. The Chrome team publishes two lists, with
+distinct semantics:
 
  * [log_list.json](https://www.gstatic.com/ct/log_list/v3/log_list.json)
    contains logs that are `Qualified`, `Usable`, or `Retired` as of when the
-   list was generated.
+   list was generated. These logs are those included in the Chrome browser for
+   evaluating compliance with Chrome's [CT Policy](ct_policy.md).
  * [all_logs_list.json](https://www.gstatic.com/ct/log_list/v3/all_logs_list.json)
-   contains the logs in `log_list.json`, alongside logs that may be `Pending`,
-   `Retired`, or have never applied for inclusion in Chrome's log list.
+   contains all logs known to and tracked by the Chrome team, including the logs
+   in `log_list.json`, logs that are `Pending` or `Retired`, as well as
+   additional logs that have not applied for inclusion in Chrome's log list.
 
 Both of these lists follow a published log list
 [schema](https://www.gstatic.com/ct/log_list/v3/log_list_schema.json). Chrome

--- a/log_lists.md
+++ b/log_lists.md
@@ -22,40 +22,40 @@ key](https://www.gstatic.com/ct/log_list/v3/log_list_pubkey.pem).
 file](https://www.gstatic.com/ct/log_list/v3/log_list.zip).
 
 ## Log list changes
-Chrome's CT Log Lists are updated daily. Most changes to log states included in
-the CT Log Lists, and all schema or URL changes, are announced on
+Chrome's log lists are updated daily. Changes to the log lists' schema or URL
+are announced on
 [ct-policy@](https://groups.google.com/a/chromium.org/g/ct-policy/). Users of
 the log list should subscribe to and follow
 [ct-policy@](https://groups.google.com/a/chromium.org/g/ct-policy/) to ensure
 they stay apprised of any changes that may affect them.
 
 ## Availability, and SLAs
-Chrome's CT Log Lists are offered without SLA or availability guarantee. Google
-endeavors to ensure that the CT Log Lists are consistently available to enable
+Chrome's CT log lists are offered without SLA or availability guarantee. Google
+endeavors to ensure that the CT log lists are consistently available to enable
 authorized uses, however, consumers are encouraged to cache recent versions of
-the CT Log Lists to account for downtime or other issues in the published Lists.
+the CT log lists to account for downtime or other issues in the published Lists.
 
 ## Acceptable Use Policy
-Google Chrome makes its CT Log Lists available for the purposes of certificate
+Google Chrome makes its CT log lists available for the purposes of certificate
 submitters (such as certification authorities) and CT monitors and auditors
 wishing to remain compatible with, or investigate the contents of, the CT and
 WebPKI ecosystems.
 
-**Chrome's CT Log Lists may not be used to facilitate CT enforcement in TLS
+**Chrome's CT log lists may not be used to facilitate CT enforcement in TLS
 clients other than Chrome without explicit written permission from Chrome's CT
 team.**
 
-Unauthorized reliance on Chrome's CT Log Lists endangers not just your users,
+Unauthorized reliance on Chrome's CT log lists endangers not just your users,
 but Chrome users and the CT ecosystem as a whole. If you are exploring adding CT
 enforcement into your user agent, the Chrome CT team is happy to talk to you
 about how to do that in a way that is safe and compatible with the broader CT
 ecosystem.
 
-Using Chrome's CT Log List out of line with this policy is done at your own
-risk, and may result in breakage of your application. Google must be able to
-make changes to the CT Log Lists in response to incidents in the CT ecosystem so
-as to maintain the safety and security of Chrome users. Google may take steps to
-ensure that third-party dependencies on the CT Log Lists do not risk Google's
-ability to respond to such incidents, including unannounced changes to the log
-list to disrupt unauthorized use.
+Using Chrome's CT log lists out of line with this policy is done at your own
+risk, and is likely to result in the breakage of your application. Google must
+be able to make changes to the CT log lists in response to incidents in the CT
+ecosystem so as to maintain the safety and security of Chrome users, so Google
+may take steps to ensure that third-party dependencies on the CT log lists do
+not risk Google's ability to respond to such incidents, including unannounced
+changes to the log list to disrupt unauthorized use.
 

--- a/log_lists.md
+++ b/log_lists.md
@@ -1,8 +1,7 @@
 # Chrome's CT Log Lists
 
 The Chrome team publishes known CT logs (collectively the "CT Log
-Lists"), predominately in JSON format. The Chrome team publishes two lists, with
-distinct semantics:
+Lists") for public consumption via two lists, each with distinct semantics:
 
  * [log_list.json](https://www.gstatic.com/ct/log_list/v3/log_list.json)
    contains logs that are `Qualified`, `Usable`, or `Retired` as of when the

--- a/log_policy.md
+++ b/log_policy.md
@@ -47,8 +47,10 @@ the new CT logs in their existing CT log operator bug:
 * A description of the logs, including applicable policies or requirements for
   logging certificates, and whether these logs are compliant with RFC6962 or
   static-ct-api v1.0.0.
-* A JSON object (one per log) containing:
-    * a public HTTP endpoint that responds to all Log Client Messages indicated
+* A JSON object (one per log), conform to the [provided
+  schema](inclusion_request_schema.json), either provided directly in the log
+  inclusion bug or via per-log URLs, containing:
+    * a public HTTP endpoint that responds to all log client messages indicated
       in RFC 6962, Section 4, or HTTP endpoints responding to Submission and
       Monitoring APIs specified in
       [c2sp.org/static-ct-api@v1.0.0](https://c2sp.org/static-ct-api@v1.0.0), as
@@ -57,15 +59,11 @@ the new CT logs in their existing CT log operator bug:
       structure, base64-encoded,
     * the SHA-256 hash of the log's public key, base64-encoded (i.e. the LogID
       provided in SCTs issued by the log),
-    * the Maximum Merge Delay (MMD) of the Log, and
-    * the expiry range of the Log.
-* The initial set of Accepted Root Certificates of the Logs.
-* Whether the Logs will reject submissions for expired or revoked certificates.
-* A description of any rate limiting policies applied to the Logs.
-
-The JSON objects must conform to the [provided
-schema](inclusion_request_schema.json) and may be provided either directly in
-the log inclusion bug or via per-log URLs.
+    * the Maximum Merge Delay (MMD) of the log, and
+    * the expiry range of the log.
+* The initial set of Accepted Root Certificates of the logs.
+* Whether the logs will reject submissions for expired or revoked certificates.
+* A description of any rate limiting policies applied to the logs.
 
 Note that certificate expiry ranges for a set of logs must be contiguous, with
 no gaps, and each log's expiry range should be between 3 and 12 months.

--- a/log_policy.md
+++ b/log_policy.md
@@ -13,39 +13,39 @@ Google from time to time.
 ---
 
 ## Application Process
-Before applying for their first CT Logs to be added to Chrome, new CT Log
-Operators should first read and fully comprehend the ongoing requirements for CT
-Logs specified in this Policy. Once a Log Operator is confident they can meet
-these requirements and has deployed a set of temporally-sharded CT Logs ready
-for application, they should follow the below process for adding these Logs to
+Before applying for their first CT logs to be added to Chrome, new CT log
+operators should first read and fully comprehend the ongoing requirements for CT
+logs specified in this Policy. Once a log operator is confident they can meet
+these requirements and has deployed a set of temporally-sharded CT logs ready
+for application, they should follow the below process for adding these logs to
 Chrome.
 
 ### New CT Log Operators
-New CT Log Operators should begin their application process by first [filing a
-new CT Log Operator
+New CT log operators should begin their application process by first [filing a
+new CT log operator
 bug](https://issues.chromium.org/issues/new?component=1456813&template=0) on the
-Chromium Issue Tracker, and provide contact Information for the Log Operator,
+Chromium Issue Tracker, and provide contact Information for the log operator,
 including:
- * An email address that is continuously monitored by the Log Operator, and
- * a list of people authorized to represent the Log Operator when communicating
+ * An email address that is continuously monitored by the log operator, and
+ * a list of people authorized to represent the log operator when communicating
    with the Chrome team.
 
-This bug will be used to track all CT Logs operated by this Log Operator for as
-long as any Logs operated by this organization are `Pending`, `Qualified`,
-`Usable`, `ReadOnly`, or `Retired`. By creating a new CT Log Operator bug,
+This bug will be used to track all CT logs operated by this log operator for as
+long as any logs operated by this organization are `Pending`, `Qualified`,
+`Usable`, `ReadOnly`, or `Retired`. By creating a new CT log operator bug,
 applicants are asserting they are organizationally independent from all existing
-CT Log Operators, which can be observed in the [log lists](log_lists.md) hosted
+CT log operators, which can be observed in the [log lists](log_lists.md) hosted
 by Google. If an organizational change occurs that alters this independence, CT
-Log Operators are required to notify Chrome at
+log operators are required to notify Chrome at
 chrome-certificate-transparency@google.com as soon as possible.
 
 ### Existing CT Log Operators
-Once the Chrome team has confirmed the Log Operator's contact information, or if
-an existing Log Operator is applying for additional CT Logs to be added to
-Chrome,  the CT Log Operator must next provide the following information about
-the new CT Logs in their existing CT Log Operator bug:
-* A description of the Logs, including applicable policies or requirements for
-  logging certificates, and whether these Logs are compliant with RFC6962 or
+Once the Chrome team has confirmed the log operator's contact information, or if
+an existing log operator is applying for additional CT logs to be added to
+Chrome,  the CT log operator must next provide the following information about
+the new CT logs in their existing CT log operator bug:
+* A description of the logs, including applicable policies or requirements for
+  logging certificates, and whether these logs are compliant with RFC6962 or
   static-ct-api v1.0.0.
 * A JSON object (one per log) containing:
     * a public HTTP endpoint that responds to all Log Client Messages indicated
@@ -53,9 +53,9 @@ the new CT Logs in their existing CT Log Operator bug:
       Monitoring APIs specified in
       [c2sp.org/static-ct-api@v1.0.0](https://c2sp.org/static-ct-api@v1.0.0), as
       appropriate,
-    * the Log's public key, provided as a DER-encoded ASN.1 SubjectPublicKeyInfo
+    * the log's public key, provided as a DER-encoded ASN.1 SubjectPublicKeyInfo
       structure, base64-encoded,
-    * the SHA-256 hash of the Log's public key, base64-encoded (i.e. the LogID
+    * the SHA-256 hash of the log's public key, base64-encoded (i.e. the LogID
       provided in SCTs issued by the log),
     * the Maximum Merge Delay (MMD) of the Log, and
     * the expiry range of the Log.
@@ -67,18 +67,18 @@ The JSON objects must conform to the [provided
 schema](inclusion_request_schema.json) and may be provided either directly in
 the log inclusion bug or via per-log URLs.
 
-Note that certificate expiry ranges for a set of Logs must be contiguous, with
+Note that certificate expiry ranges for a set of logs must be contiguous, with
 no gaps, and each log's expiry range should be between 3 and 12 months.
 
-After acceptance, Google will monitor the Logs, including via random compliance
+After acceptance, Google will monitor the logs, including via random compliance
 testing, prior to its inclusion within Chrome. Such compliance testing will
-include, but is not limited to, verifying the Logs' conformance to RFC 6962 or
-static-ct-api v1.0.0 (as appropriate), confirming the Logs' availability meets
-the requirements of this Policy, and confirming the Logs are append-only and
+include, but is not limited to, verifying the logs' conformance to RFC 6962 or
+static-ct-api v1.0.0 (as appropriate), confirming the logs' availability meets
+the requirements of this Policy, and confirming the logs are append-only and
 consistent from every point of view.
 
-To enable compliance monitoring, Log Operators must include Google's Merge Delay
-Monitor Root certificate in the set of accepted root certificates of their Logs.
+To enable compliance monitoring, log operators must include Google's Merge Delay
+Monitor Root certificate in the set of accepted root certificates of their logs.
 Log operators should expect ongoing querying of their logs from Google's
 compliance monitoring infrastructure throughout the lifetime of the log.
 
@@ -97,45 +97,45 @@ possible, Chrome's requirements are equivalent between static-ct-api and RFC
 ---
 
 ## Ongoing Requirements of Included Logs
-In order for their Logs to remain included within Chrome after first becoming
-`Qualified`, Log Operators must continue to operate these Logs in accordance
-with this Policy. Log Operators must:
+In order for their logs to remain included within Chrome after first becoming
+`Qualified`, log operators must continue to operate these logs in accordance
+with this Policy. Log operators must:
 * Monitor the
   [ct-policy@chromium.org](https://groups.google.com/a/chromium.org/forum/#!forum/ct-policy)
-  group for relevant updates to policy or requirements for CT Log Operators.
-* Incorporate a certificate for which an SCT has been issued by the Log within
+  group for relevant updates to policy or requirements for CT log operators.
+* Incorporate a certificate for which an SCT has been issued by the log within
   the MMD.
-    * When Logs receive a logging submission for an already-incorporated
-      certificate, Logs must either return an existing SCT or, if creating a new
+    * When logs receive a logging submission for an already-incorporated
+      certificate, logs must either return an existing SCT or, if creating a new
       one, add another certificate entry within the MMD such that the new SCT
-      can be verified using the Log's CT APIs
-* Maintain Log availability of 99% or above.
+      can be verified using the log's CT APIs
+* Maintain log availability of 99% or above.
     * Log availability is measured on a per-endpoint basis over a 90-day rolling
       average from all requests made to the log by the Chrome team's compliance
       monitoring infrastructure. The log's overall availability is represented
       by the minimum of all per-endpoint availabilities.
     * Behavior that results in reduced availability includes, but is not limited
-      to: network level outages, expiration of the Log's SSL certificate, a
+      to: network level outages, expiration of the log's SSL certificate, a
       failure to accept new Certificates to be logged (with the exception of the
-      conditions defined in the Logging Submission Acceptance section below),
+      conditions defined in the Logging Submission Policy section below),
       HTTP response status codes other than 200, or responses that include data
       that does not conform to the log's corresponding API specification.
-* Ensure their Logs conform to the totality of the API specification indicated
-  in the Log's application.
-* Maintain the append-only property of the Log by providing consistent views of
+* Ensure their logs conform to the totality of the API specification indicated
+  in the log's application.
+* Maintain the append-only property of the log by providing consistent views of
   the Merkle Tree at all times and to all parties.
-* Not impose conditions on retrieving or sharing data from the Logs.
+* Not impose conditions on retrieving or sharing data from the logs.
 * Not present two or more conflicting views of the Merkle Tree at different
   times and/or to different parties.
 * Accept certificates issued by Google's Merge Delay Monitor Root to enable
-  Google to monitor the Log's compliance to these policies.
+  Google to monitor the log's compliance to these policies.
 * Notify the Chrome team of any and all changes to information gathered during
-  the Log Inclusion by detailing such changes in an update to the CT Log
-  Operator bug on the [Chromium Issue
+  the log inclusion process by detailing such changes in an update to the CT log
+  operator bug on the [Chromium Issue
   Tracker](https://issues.chromium.org/issues?q=status:open%20componentid:1456813)
-  in which they requested Log Inclusion.
+  in which they requested log Inclusion.
 
-Google will notify Log Operators of changes to these requirements as well as
+Google will notify log operators of changes to these requirements as well as
 effective dates for those changes via announcements to the
 [ct-policy@chromium.org](https://groups.google.com/a/chromium.org/forum/#!forum/ct-policy).
 
@@ -164,13 +164,13 @@ is kept apprised of findings and actions.
 
 ## Logging Submission Policy
 ### Accepted Root Certificates
-In order to maintain broad utility to Chrome and its users, CT Logs are expected
+In order to maintain broad utility to Chrome and its users, CT logs are expected
 to accept logging submissions from CAs that are trusted by default in Chrome
 across all its supported platforms, including ChromeOS, Android, Linux, Windows,
-macOS, iOS. If a Log Operator plans to restrict the set of Accepted Root
-Certificates, this should be clearly stated in the CT Log Operator Application
+macOS, iOS. If a log operator plans to restrict the set of Accepted Root
+Certificates, this should be clearly stated in the CT log operator application
 as well as the rationale for this restriction. **Note:** This restriction may
-prevent a CT Log from being accepted by Chrome for inclusion.
+prevent a CT log from being accepted by Chrome for inclusion.
 
 The CCADB offers [a
 report](https://ccadb.my.salesforce-sites.com/ccadb/RootCACertificatesIncludedByRSReportCSV)
@@ -181,71 +181,71 @@ logs to accept submissions from roots with CAs currently under consideration for
 inclusion in any of those root stores, available via a [separate CCADB
 report](https://ccadb.my.salesforce-sites.com/ccadb/RootCACertificatesInclusionReportCSV).
 
-So long as the CT Log Operator bug indicates which logs ingest which CCADB
+So long as the CT log operator bug indicates which logs ingest which CCADB
 reports, operators that automatically add accepted roots to reflect updates to
-these reports may do so without updating their CT Log Operator bug on each
+these reports may do so without updating their CT log operator bug on each
 update.  Log operators should not automatically remove roots from logs as a
 result of their removal from CCADB reports so as to avoid availability,
 reliability, or accuracy issues in the CCADB report compromising the
 availability of dependent logs.
 
 ### Rejecting Logging Submissions
-CT Logs are permitted to reject logging submissions for certificates that meet
+CT logs are permitted to reject logging submissions for certificates that meet
 certain conditions, such as being expired or revoked at the time the submission
-was made. A logging rejection means that the CT Log will not incorporate a given
+was made. A logging rejection means that the CT log will not incorporate a given
 certificate entry into the Merkle Tree even if the certificate chains to an
 Accepted Root Certificate. Rejected logging submissions **must not** be issued
-an SCT by the CT Log.
+an SCT by the CT log.
 
-If specified within the Application, a Log may reject submission to log
+If specified within the Application, a log may reject submission to log
 certificates that chain up to an Accepted Root Certificate based on one or more
-of the following conditions: 
-* **Certificate Revoked:** If the Log determines that a certificate has been
-  revoked by the issuing CA, it may reject the logging submission. If the Log is
+of the following conditions:
+* **Certificate Revoked:** If the log determines that a certificate has been
+  revoked by the issuing CA, it may reject the logging submission. If the log is
   unable to determine revocation status, it must accept the logging submission
-  and incorporate the entry into the Merkle Tree within the Log's MMD.
+  and incorporate the entry into the Merkle Tree within the log's MMD.
 * **Certificate Expired:** If a logging submission includes a certificate whose
   notAfter timestamp represents a point in time before the logging submission
-  was made, the Log may refuse to log the certificate entry. This criteria may
-  be used even by legacy non-sharded CT Logs that do not set certificate expiry
+  was made, the log may refuse to log the certificate entry. This criteria may
+  be used even by legacy non-sharded CT logs that do not set certificate expiry
   ranges.
-* **TLS Server Auth EKU:** The Log may reject logging submissions for
+* **TLS Server Auth EKU:** The log may reject logging submissions for
   certificates that do not contain the `id-kp-serverAuth` Extended Key Usage
   (EKU).
 
 The primary purpose of allowing rejection of certain logging submissions is to
-provide Log Operators with greater control over the growth and operation of
-their Logs while still performing their core function. Additionally, these
-criteria allow Logs to be shielded from certain types of Denial of Service such
+provide log operators with greater control over the growth and operation of
+their logs while still performing their core function. Additionally, these
+criteria allow logs to be shielded from certain types of Denial of Service such
 as being spammed with the corpus of all expired certificates and being unable to
 respond to legitimate logging submissions.
 
 ### Temporal Sharding
-In order to provide ecosystem agility and to control the growth of CT Log sizes,
-new CT Logs must be *temporally sharded*, defining a *certificate expiry range*
+In order to provide ecosystem agility and to control the growth of CT log sizes,
+new CT logs must be *temporally sharded*, defining a *certificate expiry range*
 denoted in the form of two dates: [rangeBegin, rangeEnd). The certificate expiry
-range allows a Log to reject otherwise valid logging submissions for
+range allows a log to reject otherwise valid logging submissions for
 certificates that expire before or after this defined range, thus partitioning
-the set of publicly-trusted certificates that each Log will accept. 
+the set of publicly-trusted certificates that each log will accept.
 
-In order to have their Logs accepted for inclusion, Log Operators should deploy
-and operate their Logs according to the following:
-* The certificate expiry ranges for CT Logs must be no longer than one calendar
-  year and should be no shorter than six months
-* CT Logs must reject logging submissions for certificates whose notAfter
-  timestamp falls outside the certificate expiry range
-* Log Operators should deploy enough sharded CT Logs so that their certificate
-  expiry ranges cover a contiguous period of time, spanning from the current
-  time to 3-4 years in the future
-    * Many Log Operators find it convenient to define these ranges on the
+In order to have their logs accepted for inclusion, log operators should deploy
+and operate their logs according to the following:
+* The certificate expiry ranges for CT logs must be no longer than one calendar
+  year and should be no shorter than six months.
+* CT logs must reject logging submissions for certificates whose notAfter
+  timestamp falls outside the certificate expiry range.
+* Log operators should deploy enough sharded CT logs so that their certificate
+  expiry ranges cover a contiguous period of time, spanning from the current.
+  time to 3-4 years in the future.
+    * Many log operators find it convenient to define these ranges on the
       calendar year, so an application in 2020 would include e.g. Log2020,
       Log2021, Log2022, Log2023.
-* CT Logs will be removed from Chrome once their certificate expiry range has
-  passed. When Log Operators in good standing have one of their Logs removed in
-  this manner, they should stand up a new CT Log whose expiry range extends the
-  set of contiguous expiry ranges 
+* CT logs will be removed from Chrome once their certificate expiry range has
+  passed. When log operators in good standing have one of their logs removed in
+  this manner, they should stand up a new CT log whose expiry range extends the
+  set of contiguous expiry ranges.
     * Following the example from above, when Log2020 is removed in early 2021,
-      the Log Operator should stand up Log2024 and apply for its inclusion,
+      the log operator should stand up Log2024 and apply for its inclusion,
       following the Application Process defined above.
 
 ### Rate Limiting

--- a/log_policy.md
+++ b/log_policy.md
@@ -198,19 +198,19 @@ include:
  * Log downtime caused by a maintenance window preannounced to
    [ct-policy@](https://groups.google.com/a/chromium.org/forum/#!forum/ct-policy).
  * A log violating the MMD due to an unpredictable spike in load, subsequently
-   resolved by providing additional resources.
+   resolved by providing additional resources or adjusting rate limits.
  * A temporary log outage caused by an outage of a 3rd-party dependency (e.g. a
    cloud provider).
 
-Some incidents necessitate the removal of impacted logs regardless of other
-factors. These incidents can include, but are not limited to:
- * Incidents that prevent the log from being cryptographically verified (e.g.
-   bit flips included in the merkle tree structure).
- * Incidents that result in the log failing to include a certificate for which
-   the log has issued an SCT, even after several days.
- * Extended availability issues, such as when the log's availability over any 90
-   day window drops below 95%, or the log has an ongoing/intermittent
-   availability issue lasting two or more weeks.
+In addition to incidents that prevent the log from being cryptographically
+verified (e.g. signing inconsistent STHs, bit flips included in the merkle tree
+structure), incidents such as the following will typically result in log
+removal:
+ * Logs failing to include a certificate for which the log has issued an SCT,
+   even after several days.
+ * Logs experiencing extended availability issues, such as when the log's
+   availability over any 90 day window drops below 95%, or the log has an
+   ongoing/intermittent availability issue lasting two or more weeks.
 
 Regardless of incident severity, log operators should take steps to prevent
 their logs from experiencing similar incidents in the future.

--- a/log_policy.md
+++ b/log_policy.md
@@ -23,7 +23,7 @@ potential and current log operators to ensure those operators are successful.
 ## Application Process
 Before applying for their first CT logs to be added to Chrome, new CT log
 operators should first read and fully comprehend the ongoing requirements for CT
-logs specified in this Policy. Once a log operator is confident they can meet
+logs specified in this policy. Once a log operator is confident they can meet
 these requirements and has deployed a set of temporally-sharded CT logs ready
 for application, they should follow the below process for adding these logs to
 Chrome.
@@ -50,7 +50,7 @@ chrome-certificate-transparency@google.com as soon as possible.
 ### Existing CT Log Operators
 Once the Chrome team has confirmed the log operator's contact information, or if
 an existing log operator is applying for additional CT logs to be added to
-Chrome,  the CT log operator must next provide the following information about
+Chrome, the CT log operator must next provide the following information about
 the new CT logs in their existing CT log operator bug:
 * A description of the logs, including applicable policies or requirements for
   logging certificates, and whether these logs are compliant with RFC6962 or
@@ -80,7 +80,7 @@ After acceptance, Google will monitor the logs, including via random compliance
 testing, prior to its inclusion within Chrome. Such compliance testing will
 include, but is not limited to, verifying the logs' conformance to RFC 6962 or
 static-ct-api v1.0.0 (as appropriate), confirming the logs' availability meets
-the requirements of this Policy, and confirming the logs are append-only and
+the requirements of this policy, and confirming the logs are append-only and
 consistent from every point of view.
 
 To enable compliance monitoring, log operators must include Google's Merge Delay
@@ -105,7 +105,7 @@ possible, Chrome's requirements are equivalent between static-ct-api and RFC
 ## Ongoing Requirements of Included Logs
 In order for their logs to remain included within Chrome after first becoming
 `Qualified`, log operators must continue to operate these logs in accordance
-with this Policy. Log operators must:
+with this policy. Log operators must:
 * Monitor the
   [ct-policy@chromium.org](https://groups.google.com/a/chromium.org/forum/#!forum/ct-policy)
   group for relevant updates to policy or requirements for CT log operators.
@@ -187,7 +187,7 @@ discretion based on all information available. This typically includes the root
 cause of the incidents, the log operator’s response, and the impact Chrome's
 decision may have on the health of the broader CT ecosystem.
 
-The Chrome CT Program acknowledges that many log incidents are transient.In
+The Chrome CT Program acknowledges that many log incidents are transient. In
 these cases, removal of the log from Chrome's log list may not be best outcome
 for Chrome, Chrome's users, or the CT ecosystem. As a result, transient
 incidents where the log operator takes steps to ensure similar incidents do not

--- a/log_states.md
+++ b/log_states.md
@@ -80,7 +80,7 @@ included in Chrome.
   becoming `Qualified`, so long as they continue to comply with the [CT Log
   Policy](log_policy.md).
 * `Qualified` CT logs transition to `Retired` if they demonstrate a serious or
-  sustained pattern of CT Policy or API specification compliance issues, or if
+  sustained pattern of CT policy or API specification compliance issues, or if
   the log operator ceases operation of their CT log(s). Due to the inability for
   Chrome to distinguish between intentional and accidental non-compliance, such
   issues are treated as highest possible severity, which results in the CT log
@@ -128,7 +128,7 @@ recognizing these CT logs.
 
 **How `Usable` CT Logs transition to other states:**
 * `Usable` CT logs transition to `Retired` if they demonstrate a serious or
-  sustained pattern of CT Policy or API specification compliance issues, or if
+  sustained pattern of CT policy or API specification compliance issues, or if
   the log operator ceases operation of their CT log(s). Due to the inability for
   Chrome to distinguish between intentional and accidental non-compliance, such
   issues are treated as highest possible severity, which results in the CT log
@@ -174,7 +174,7 @@ monitoring `ReadOnly` logs until they become `Retired` or `Rejected`.
 
 **How `ReadOnly` CT Logs transition to other states:**
 * `ReadOnly` CT logs transition to `Retired` if they demonstrate a serious or
-  sustained pattern of CT Policy or API specification compliance issues, or if
+  sustained pattern of CT policy or API specification compliance issues, or if
   the log operator ceases operation of their CT log(s). Due to the inability for
   Chrome to distinguish between intentional and accidental non-compliance, such
   issues are treated as highest possible severity, which results in the CT log

--- a/log_states.md
+++ b/log_states.md
@@ -4,13 +4,13 @@ Certificate Transparency (CT) is a technology and an ecosystem designed to
 ensure that TLS certificates issued by publicly-trusted Certification
 Authorities (CAs) are detectable by website operators shortly after they are
 first able to validate in CT-enforcing user agents, such as Chrome. In order to
-achieve this goal, user agents rely on organizations called Log Operators to
-stand up and operate infrastructure called CT Logs and apply for inclusion to be
+achieve this goal, user agents rely on organizations called log operators to
+stand up and operate infrastructure called CT logs and apply for inclusion to be
 recognized by these user agents.
 
-The purpose of this document is to describe the lifecycle of a CT Log,
+The purpose of this document is to describe the lifecycle of a CT log,
 represented by a set of states and state transitions, and explain what these
-states mean for Log Operators, CAs, CT Monitors, Site Operators, and Chrome.
+states mean for log operators, CAs, CT monitors, site operators, and Chrome.
 
 ---
 
@@ -28,169 +28,169 @@ PENDING ---> QUALIFIED ---> USABLE ---> READONLY----+
    +-----------+------------+-------------+----> REJECTED
 ```
 
-In the above state machine, the nodes represent all possible CT Log states and
+In the above state machine, the nodes represent all possible CT log states and
 the directional edges represent possible state transitions. The remainder of
-this document describes how CT Logs transition into and out of these states,
-what is expected of CT Logs in these states, and finally, how the CT Log states
+this document describes how CT logs transition into and out of these states,
+what is expected of CT logs in these states, and finally, how the CT log states
 map to Chrome behavior.
 
 ---
 
 ## `Pending`
-When a Log Operator requests for a CT Log to be added to Chrome, the CT Log is
-first placed into the `Pending` state. While the Log undergoes its initial
+When a log operator requests for a CT log to be added to Chrome, the CT log is
+first placed into the `Pending` state. While the log undergoes its initial
 compliance monitoring period, it remains in the `Pending` state until it is
 either added to Chrome or a determination is made to reject the application.
 
 **How `Pending` CT Logs transition to other states:**
-* `Pending` CT Logs transition to `Qualified` when they are first added to
+* `Pending` CT logs transition to `Qualified` when they are first added to
   Chrome after a successful compliance monitoring period.
-* `Pending` CT Logs transition to `Rejected` if serious or sustained violations
+* `Pending` CT logs transition to `Rejected` if serious or sustained violations
   of the log's applicable API specification or the [CT Log
   Policy](log_policy.md) are detected during the application process, or if the
-  Log Operator indicates they are withdrawing the application for inclusion in
+  log operator indicates they are withdrawing the application for inclusion in
   Chrome.
 
 **Expected Log Behavior:**
 
-While in the `Pending` state, CT Logs are expected to abide by all ongoing
+While in the `Pending` state, CT logs are expected to abide by all ongoing
 requirements defined in the [Certificate Transparency Log
 Policy](log_policy.md), including availability requirements, API specification
-compliance, and timely notification of changes to Log Operation.
+compliance, and timely notification of changes to log Operation.
 
 **Chrome Behavior:**
 
-`Pending` Logs are not included in the CT Log List in Chrome. When evaluated in
-CT-enforcing versions of Chrome, SCTs from CT Logs in the `Pending` state at
+`Pending` logs are not included in the CT log list in Chrome. When evaluated in
+CT-enforcing versions of Chrome, SCTs from CT logs in the `Pending` state at
 time of check do not contribute towards CT Compliance for either the Embedded
 SCT or the OCSP/TLS SCT criteria.
 
 ---
 
 ## `Qualified`
-CT Logs that successfully pass the initial compliance monitoring period are
+CT logs that successfully pass the initial compliance monitoring period are
 placed in the `Qualified` state if there are no major issues observed during
-this period. `Qualified` CT Logs are added to the list checked into Chromium and
-get included in a future version of Chrome. `Qualified` CT Logs must meet an
+this period. `Qualified` CT logs are added to the list checked into Chromium and
+get included in a future version of Chrome. `Qualified` CT logs must meet an
 ongoing set of compliance and availability requirements in order to remain
 included in Chrome.
 
 **How `Qualified` CT Logs transition to other states:**
-* `Qualified` CT Logs transition to `Usable` within a fixed period of time after
+* `Qualified` CT logs transition to `Usable` within a fixed period of time after
   becoming `Qualified`, so long as they continue to comply with the [CT Log
   Policy](log_policy.md).
-* `Qualified` CT Logs transition to `Retired` if they demonstrate a serious or
+* `Qualified` CT logs transition to `Retired` if they demonstrate a serious or
   sustained pattern of CT Policy or API specification compliance issues, or if
-  the Log Operator ceases operation of their CT Log(s). Due to the inability for
+  the log operator ceases operation of their CT log(s). Due to the inability for
   Chrome to distinguish between intentional and accidental non-compliance, such
-  issues are treated as highest possible severity, which results in the CT Log
+  issues are treated as highest possible severity, which results in the CT log
   being `Retired`.
-* `Qualified` CT Logs transition to `Rejected` if all certificates contained
+* `Qualified` CT logs transition to `Rejected` if all certificates contained
   therein are expired or if it is past the end of their certificate expiry range
-  specified in their Chromium CT Log application. Notably, the `Qualified` to
-  `Rejected` transition is not used as a more severe response to a CT Log’s
+  specified in their Chromium CT log application. Notably, the `Qualified` to
+  `Rejected` transition is not used as a more severe response to a CT log’s
   compliance issues.
 
 **Expected Log Behavior:**
 
-While in the `Qualified` state, CT Logs are expected to abide by all ongoing
+While in the `Qualified` state, CT logs are expected to abide by all ongoing
 requirements defined in the [Certificate Transparency Log
 Policy](log_policy.md), including availability requirements, API specification
-compliance, and timely notification of changes to Log Operation.
+compliance, and timely notification of changes to log operation.
 
 **Chrome Behavior:**
 
-`Qualified` CT Logs are periodically imported to the list of CT Logs recognized
-by Chrome. When evaluated in CT-enforcing versions of Chrome, SCTs from CT Logs
+`Qualified` CT logs are periodically imported to the list of CT logs recognized
+by Chrome. When evaluated in CT-enforcing versions of Chrome, SCTs from CT logs
 in the `Qualified` state at time of check contribute towards CT Compliance for
 both the Embedded SCT and the OCSP/TLS SCT criteria.
 
 ---
 
 ## `Usable`
-Once a CT Log becomes `Qualified`, there will be a period of time in which older
+Once a CT log becomes `Qualified`, there will be a period of time in which older
 versions of Chrome are still enforcing CT but are not yet aware of this newly
-`Qualified` CT Log. Certificates accompanied by SCTs from such a
-newly-`Qualified` CT Log would fail validation in these non-updated clients, so
-the `Qualified` Log state is insufficient on its own to indicate safeness for
-production CT Logging. The `Usable` Log state captures this notion of safety by
+`Qualified` CT log. Certificates accompanied by SCTs from such a
+newly-`Qualified` CT log would fail validation in these non-updated clients, so
+the `Qualified` log state is insufficient on its own to indicate safeness for
+production CT logging. The `Usable` log state captures this notion of safety by
 indicating to CAs and site operators that all CT-enforcing versions of Chrome
-now recognize a given newly-`Qualified` CT Log.
+now recognize a given newly-`Qualified` CT log.
 
-Newly-`Qualified` CT Logs become `Usable` when they have been added to the CT
-Log List for all CT-enforcing versions of Chrome. This is achieved either by
-Chrome clients updating to a version in which this CT Log has been added or by
+Newly-`Qualified` CT logs become `Usable` when they have been added to the CT
+log list for all CT-enforcing versions of Chrome. This is achieved either by
+Chrome clients updating to a version in which this CT log has been added or by
 older clients becoming 10 or more weeks out-of-date and thus disabling CT
 enforcement. Rather than being a distinct state recognized by any given Chrome
 client, the `Usable` state can be thought of as a signal to the CT ecosystem,
 representing the distributed state of all CT-enforcing user agents now
-recognizing these CT Logs.
+recognizing these CT logs.
 
 **How `Usable` CT Logs transition to other states:**
-* `Usable` CT Logs transition to `Retired` if they demonstrate a serious or
+* `Usable` CT logs transition to `Retired` if they demonstrate a serious or
   sustained pattern of CT Policy or API specification compliance issues, or if
-  the Log Operator ceases operation of their CT Log(s). Due to the inability for
+  the log operator ceases operation of their CT log(s). Due to the inability for
   Chrome to distinguish between intentional and accidental non-compliance, such
-  issues are treated as highest possible severity, which results in the CT Log
+  issues are treated as highest possible severity, which results in the CT log
   being `Retired`.
-* `Usable` CT Logs transition to `Rejected` if all certificates contained
+* `Usable` CT logs transition to `Rejected` if all certificates contained
   therein are expired or if it is past the end of their certificate expiry range
-  specified in their CT Log application. Notably, the `Usable` to `Rejected`
-  transition is not used as a more severe response to a CT Log’s compliance
+  specified in their CT log application. Notably, the `Usable` to `Rejected`
+  transition is not used as a more severe response to a CT log’s compliance
   issues.
 
 **Expected Log Behavior:**
 
-While in the `Usable` state, CT Logs are expected to abide by all ongoing
+While in the `Usable` state, CT logs are expected to abide by all ongoing
 requirements defined in the [Certificate Transparency Log
 Policy](log_policy.md), including availability requirements, API specification
-compliance, and timely notification of changes to Log Operation.
+compliance, and timely notification of changes to log operation.
 
 **Chrome Behavior:**
 
 The `Usable` state is not a state that is specifically recognized by Chrome
 clients and is functionally equivalent to `Qualified` and `ReadOnly` in terms of
-SCTs from such Logs contributing towards CT compliance.
+SCTs from such logs contributing towards CT compliance.
 
-`Usable` CT Logs are imported to the list of CT Logs recognized by Chrome,
+`Usable` CT logs are imported to the list of CT logs recognized by Chrome,
 usually from when they first became `Qualified`. When evaluated in CT-enforcing
-versions of Chrome, SCTs from CT Logs in the `Usable` state at time of check
+versions of Chrome, SCTs from CT logs in the `Usable` state at time of check
 contribute towards CT Compliance for both the Embedded SCT and the OCSP/TLS SCT
 criteria.
 
 ---
 
 ## `ReadOnly`
-If a Log Operator wishes to cease accepting certificate logging requests, they
-may request that their `Qualified` or `Usable` CT Log(s) be placed in the
-`ReadOnly` state. CT Logs that become `ReadOnly` mode are making an assertion
-that they will stop issuing new SCTs, but will continue to operate the CT Log in
+If a log operator wishes to cease accepting certificate logging requests, they
+may request that their `Qualified` or `Usable` CT log(s) be placed in the
+`ReadOnly` state. CT logs that become `ReadOnly` mode are making an assertion
+that they will stop issuing new SCTs, but will continue to operate the CT log in
 accordance with the [Certificate Transparency Log Policy](log_policy.md).
 
-When a Log becomes `ReadOnly`, the final tree size is published to the
-Google-hosted [CT Log List](log_lists.md) to signal that this Log should not
-grow past this point. To help ensure this behavior, CT Monitors should continue
-monitoring `ReadOnly` Logs until they become `Retired` or `Rejected`.
+When a log becomes `ReadOnly`, the final tree size is published to the
+Google-hosted [CT Log List](log_lists.md) to signal that this log should not
+grow past this point. To help ensure this behavior, CT monitors should continue
+monitoring `ReadOnly` logs until they become `Retired` or `Rejected`.
 
 **How `ReadOnly` CT Logs transition to other states:**
-* `ReadOnly` CT Logs transition to `Retired` if they demonstrate a serious or
+* `ReadOnly` CT logs transition to `Retired` if they demonstrate a serious or
   sustained pattern of CT Policy or API specification compliance issues, or if
-  the Log Operator ceases operation of their CT Log(s). Due to the inability for
+  the log operator ceases operation of their CT log(s). Due to the inability for
   Chrome to distinguish between intentional and accidental non-compliance, such
-  issues are treated as highest possible severity, which results in the CT Log
+  issues are treated as highest possible severity, which results in the CT log
   being `Retired`.
-* `ReadOnly` CT Logs transition to `Rejected` if all certificates contained
+* `ReadOnly` CT logs transition to `Rejected` if all certificates contained
   therein are expired or if it is past the end of their certificate expiry range
-  specified in their CT Log application. Notably, the `ReadOnly` to `Rejected`
-  transition is not used as a more severe response to a CT Log’s compliance
+  specified in their CT log application. Notably, the `ReadOnly` to `Rejected`
+  transition is not used as a more severe response to a CT log’s compliance
   issues.
 
 **Expected Log Behavior:**
 
-While in the `ReadOnly` state, CT Logs are expected to abide by all ongoing
+While in the `ReadOnly` state, CT logs are expected to abide by all ongoing
 requirements defined in the [Certificate Transparency Log
 Policy](log_policy.md), including availability requirements, API specification
-compliance, and timely notification of changes to Log Operation.
+compliance, and timely notification of changes to log Operation.
 
 **Chrome Behavior:**
 
@@ -198,31 +198,31 @@ The `ReadOnly` state is not a state that is directly recognized by Chrome
 clients, but rather is treated as functionally equivalent to `Qualified` and
 `Usable` in terms of CT enforcement.
 
-`ReadOnly` CT Logs are imported to the list of CT Logs recognized by Chrome,
+`ReadOnly` CT logs are imported to the list of CT logs recognized by Chrome,
 usually from when they first became `Qualified`. When evaluated in CT-enforcing
-versions of Chrome, SCTs from CT Logs in the `ReadOnly` state at time of check
+versions of Chrome, SCTs from CT logs in the `ReadOnly` state at time of check
 contribute towards CT Compliance for both the Embedded SCT and the OCSP/TLS SCT
 criteria.
 
 ---
 
 ## `Retired`
-A `Retired` Log is one that was at one point `Qualified`, but has stopped being
-relied upon for the creation of new SCTs. CT Logs usually enter the `Retired`
+A `Retired` log is one that was at one point `Qualified`, but has stopped being
+relied upon for the creation of new SCTs. CT logs usually enter the `Retired`
 state due to a failure to adhere to the ongoing requirements outlined in the
 [Certificate Transparency Log Policy](log_policy.md).
 
-To increase the CT ecosystem’s resilience against CT Log failure, existing
-certificates relying on embedded SCTs that were issued before a Log’s Retirement
+To increase the CT ecosystem’s resilience against CT log failure, existing
+certificates relying on embedded SCTs that were issued before a log’s Retirement
 timestamp can still contribute to CT Compliance for certificates using Embedded
 SCTs. However, since they can be modified without certificate re-issuance, SCTs
-delivered via OCSP or TLS must come from CT Logs that are `Qualified`, `Usable`,
+delivered via OCSP or TLS must come from CT logs that are `Qualified`, `Usable`,
 or `ReadOnly` at time of check.
 
 **How `Retired` CT Logs transition to other states:**
-* `Retired` CT Logs transition to `Rejected` if all certificates contained
+* `Retired` CT logs transition to `Rejected` if all certificates contained
   therein are expired or if it is past the end of their certificate expiry range
-  specified in their CT Log application.
+  specified in their CT log application.
 
 **Expected Log Behavior:**
 
@@ -232,63 +232,62 @@ and securely delete the Log key.
 
 **Chrome Behavior:**
 
-`Retired` Logs are included in the [CT Log List](log_lists.md) that is shipped
-in Chrome, but include both an indicator that the Log is now `Retired` as well
+`Retired` logs are included in the [CT Log List](log_lists.md) that is shipped
+in Chrome, but include both an indicator that the log is now `Retired` as well
 as the corresponding Retirement timestamp.
 
-Embedded SCTs from `Retired` Logs count towards certain requirements for CT
+Embedded SCTs from `Retired` logs count towards certain requirements for CT
 compliance; however, as outlined in [Chrome CT Policy](ct_policy.md), in order
-for a certificate to be CT Compliant, SCTs from `Retired` Logs must be
-accompanied by at least one SCT from a Log that was `Qualified`, `Usable`, or
+for a certificate to be CT Compliant, SCTs from `Retired` logs must be
+accompanied by at least one SCT from a log that was `Qualified`, `Usable`, or
 `ReadOnly` at time of check.
 
-SCTs from `Retired` Logs that are delivered via OCSP or TLS do not contribute
+SCTs from `Retired` logs that are delivered via OCSP or TLS do not contribute
 towards CT Compliance, and failure to include sufficient SCTs from `Qualified`,
-`Usable`, or `ReadOnly` CT Logs at time of check will result in certificate
+`Usable`, or `ReadOnly` CT logs at time of check will result in certificate
 validation failure in CT-enforcing versions of Chrome.
 
 ---
 
 ## `Rejected`
-When all certificates contained in a CT Log have expired and the CT Log is no
+When all certificates contained in a CT log have expired and the CT log is no
 longer issuing new SCTs in response to logging requests, it will transition into
-the `Rejected` state. Additionally, if a CT Log fails its initial compliance
+the `Rejected` state. Additionally, if a CT log fails its initial compliance
 monitoring period, it will skip straight to the `Rejected` state, since there
-should be no still-valid certificates relying on SCTs from this Log.
+should be no still-valid certificates relying on SCTs from this log.
 
-SCTs from `Rejected` CT Logs do not contribute in any way towards CT Compliance
+SCTs from `Rejected` CT logs do not contribute in any way towards CT Compliance
 and should not be embedded in new certificates or delivered via OCSP or TLS.
 
-Despite the fact that `Rejected` CT Logs are not included in either the CT Log
-List shipped in Chrome or the Log List hosted by Google, they are tracked
-internally to ensure that keys are not reused in future CT Logs applying for
-inclusion.
+Though `Rejected` CT logs are not included in Chrome's published [CT log
+lists](log_lists.md), they are tracked internally to ensure that keys are not
+reused in future CT logs applying for inclusion.
 
-**How `Rejected` CT Logs transition to other states:**
-* The `Rejected` state is the terminal state of the CT Log Lifecycle state
-  machine. Once a CT Log enters the `Rejected` state, it can no longer
+**How `Rejected` CT logs transition to other states:**
+* The `Rejected` state is the terminal state of the CT log lifecycle state
+  machine. Once a CT log enters the `Rejected` state, it can no longer
   transition to any of the other defined states.
 
 **Expected Log Behavior:**
 
-Once a CT Log becomes `Rejected`, there are no longer any expectations that it
-continues operation. Log Operators are encouraged to turn down `Rejected` CT
-Logs and securely delete the Log key.
+Once a CT log becomes `Rejected`, there are no longer any expectations that it
+continues operation. Log operators are encouraged to turn down `Rejected` CT
+logs and securely delete the log key.
 
 **Chrome Behavior:**
 
-`Rejected` Logs are not included in the CT Log List in Chrome. When evaluated in
-CT-enforcing versions of Chrome, SCTs from CT Logs in the `Rejected` state at
+`Rejected` logs are not included in the CT Log List in Chrome. When evaluated in
+CT-enforcing versions of Chrome, SCTs from CT logs in the `Rejected` state at
 time of check do not contribute towards CT Compliance for either the Embedded
 SCT or the OCSP/TLS SCT criteria.
 
 ---
 
 ## Considerations for Chromium Embedders and other CT User Agents
-With these high-level Log state descriptions in mind, each CT-enforcing user
+With these high-level log state descriptions in mind, each CT-enforcing user
 agent may wish to further specify additional context for any of these states;
 however, it is important that user agent CT Policies remain compatible with one
 another to ensure CAs and site operators can continue to issue and serve
 certificates that will successfully validate across multiple user agents. We
-welcome discussion and feedback about CT Log state definitions in the
+welcome discussion and feedback about CT log state definitions in the
 ct-policy@chromium.org discussion forum.

--- a/log_states.md
+++ b/log_states.md
@@ -226,9 +226,10 @@ or `ReadOnly` at time of check.
 
 **Expected Log Behavior:**
 
-Once a CT Log becomes `Retired`, there are no longer any expectations that it
-continues operation. Log Operators are encouraged to turn down `Retired` CT Logs
-and securely delete the Log key.
+Once a CT log becomes `Retired`, there are no longer any expectations that it
+continues operation. Log operators are encouraged, but not required, to keep
+`Retired` CT logs running for a time sufficient for log monitors to fully ingest
+the log.
 
 **Chrome Behavior:**
 


### PR DESCRIPTION
We've received feedback that it'd be useful, especially for potential new log operators, to have more clarity on log operator expectations during incidents, and what Chrome's responses might be. This change tries to offer that.

Most of this should be relatively non-controversial, but it does include a explicit few changes to policy: that we consider 90-day availability dropping below 95%, or persistent log availability issues lasting more than two weeks, to be sufficiently severe to justify log removal.

It shifts the policy towards _not_ capitalizing actors in the ecosystem (e.g. "Log Operator") and some other smaller wordsmithing.
