### PR TITLE
Remove one-6962-log requirement after 2026-04-15.

### DIFF
--- a/ct_policy.md
+++ b/ct_policy.md
@@ -61,8 +61,9 @@ by meeting one of the following criteria:
    is defined in the following table; and
 3. Among the SCTs satisfying requirement 2, at least two SCTs must be issued
    from distinct CT log operators as recognized by Chrome; and
-4. Among the SCTs satisfying requirement 2, at least one SCT must be issued from
-   a log recognized by Chrome as being RFC6962-compliant.
+4. **Before April 15, 2026:** Among the SCTs satisfying requirement 2, at least
+   one SCT must be issued from a log recognized by Chrome as being
+   RFC6962-compliant.
 
 | Certificate Lifetime | Number of SCTs from distinct CT logs |
 |:---:|:---:|
@@ -74,8 +75,9 @@ by meeting one of the following criteria:
    at the time of check; and
 2. Among the SCTs satisfying requirement 1, at least two SCTs must be issued
    from distinct CT log operators as recognized by Chrome; and
-3. Among the SCTs satisfying requirement 1, at least one SCT must be issued from
-   a CT log recognized by Chrome as being RFC6962-compliant.
+3. **Before April 15, 2026:** Among the SCTs satisfying requirement 1, at least
+   one SCT must be issued from a CT log recognized by Chrome as being
+   RFC6962-compliant.
 
 For both embedded SCTs and those delivered via OCSP or TLS, log operator
 uniqueness is defined as having separate entries within the `operators` section


### PR DESCRIPTION
Permits the use of sets of SCTs purely from static-ct-api logs after April 15, 2026.